### PR TITLE
Fix bug which ignored AMADEUS_HOST property provided by environment

### DIFF
--- a/src/main/java/com/amadeus/Configuration.java
+++ b/src/main/java/com/amadeus/Configuration.java
@@ -149,7 +149,7 @@ public class Configuration {
   // Parses environment variables and initializes the values.
   protected Configuration parseEnvironment(Map<String, String> environment) {
     setHostname(getOrDefault(environment, "HOSTNAME", hostname));
-    setHost(getOrDefault(environment, "HOOST", host));
+    setHost(getOrDefault(environment, "HOST", host));
     setLogLevel(getOrDefault(environment, "LOG_LEVEL", logLevel));
     setSsl(Boolean.parseBoolean(getOrDefault(environment, "SSL", String.valueOf(ssl))));
     setPort(Integer.parseInt(getOrDefault(environment, "PORT", String.valueOf(port))));

--- a/src/test/java/com/amadeus/AmadeusTest.java
+++ b/src/test/java/com/amadeus/AmadeusTest.java
@@ -31,6 +31,7 @@ public class AmadeusTest {
         put("AMADEUS_CLIENT_SECRET", "234");
         put("AMADEUS_LOG_LEVEL", "debug");
         put("AMADEUS_PORT", "123");
+        put("AMADEUS_HOST", "my.custom.host.com");
       }
     };
     assertTrue("should return a Configuration",
@@ -39,6 +40,7 @@ public class AmadeusTest {
     Amadeus amadeus = Amadeus.builder(environment).build();
     assertEquals(amadeus.getConfiguration().getLogLevel(), "debug");
     assertEquals(amadeus.getConfiguration().getPort(), 123);
+    assertEquals(amadeus.getConfiguration().getHost(), "my.custom.host.com");
   }
 
   /*


### PR DESCRIPTION
API documentation suggests that the user can pass a custom domain to
which the client will issue API calls, by setting an AMADEUS_HOST
property in the system environment variable. This functionality was
however broken due to a typo while reading the environment variable.

Fix bug by correcting the typo, thus picking the correct env variable.


