### PR TITLE
Do not append error detail to message when it does not exist

### DIFF
--- a/src/main/java/com/amadeus/exceptions/ResponseException.java
+++ b/src/main/java/com/amadeus/exceptions/ResponseException.java
@@ -90,7 +90,9 @@ public class ResponseException extends Exception {
           message.append(String.format("[%s] ", source.get("parameter").getAsString()));
         }
       }
-      message.append(String.format("%s", json.get("detail").getAsString()));
+      if (json.has("detail") && !json.get("detail").isJsonNull()) {
+        message.append(String.format("%s", json.get("detail").getAsString()));
+      }
     }
     return message;
   }

--- a/src/test/java/com/amadeus/ExceptionsTest.java
+++ b/src/test/java/com/amadeus/ExceptionsTest.java
@@ -152,4 +152,17 @@ public class ExceptionsTest {
     assertTrue(new ParserException(null) instanceof ResponseException);
     assertTrue(new ServerException(null) instanceof ResponseException);
   }
+
+  @Test public void testForErrorsWithoutDetail() {
+    Response response = mock(Response.class);
+    when(response.getStatusCode()).thenReturn(401);
+    String body = "{\"errors\":[{}]}";
+    JsonObject json = new JsonParser().parse(body).getAsJsonObject();
+    when(response.getResult()).thenReturn(json);
+    when(response.isParsed()).thenReturn(true);
+
+    ResponseException error = new ResponseException(response);
+    assertEquals(error.toString(), "com.amadeus.exceptions.ResponseException: [401]"
+            + "\n");
+  }
 }


### PR DESCRIPTION
Fixes #98 

## Changes for this pull request

Checks that the `detail` property in an error object is present and non-null before appending it to the message. This prevents a `NullPointerException`.