### PR TITLE
Add support for APIs that need X-HTTP-Method-Override Header

### DIFF
--- a/src/main/java/com/amadeus/Constants.java
+++ b/src/main/java/com/amadeus/Constants.java
@@ -1,5 +1,8 @@
 package com.amadeus;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A class for constant variables.
  *
@@ -22,6 +25,7 @@ public final class Constants {
   public static final String ACCEPT = "Accept";
   public static final String AUTHORIZATION = "Authorization";
   public static final String CONTENT_TYPE = "Content-Type";
+  public static final String X_HTTP_METHOD_OVERRIDE = "X-HTTP-Method-Override";
 
   // Pagination
   public static final String FIRST = "first";
@@ -38,6 +42,16 @@ public final class Constants {
   public static final String ACCESS_TOKEN = "access_token";
   public static final String EXPIRES_IN = "expires_in";
 
+  // APIs which need an X-HTTP-Method-Override GET HEADER
+  public static final List<String> APIS_WITH_EXTRA_HEADER = new ArrayList<String>() {
+    {
+      add("/v2/shopping/flight-offers");
+      add("/v1/shopping/seatmaps");
+      add("/v1/shopping/availability/flight-availabilities");
+      add("/v2/shopping/flight-offers/prediction");
+      add("/v1/shopping/flight-offers/pricing");
+    }
+  };
 
   /**
    * The caller references the constants using <tt>Consts.EMPTY_STRING</tt>,

--- a/src/main/java/com/amadeus/Request.java
+++ b/src/main/java/com/amadeus/Request.java
@@ -8,6 +8,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import lombok.Getter;
 import lombok.ToString;
@@ -141,7 +142,13 @@ public class Request {
       headers.put(Constants.AUTHORIZATION, bearerToken);
       headers.put(Constants.CONTENT_TYPE, "application/vnd.amadeus+json");
 
+      // Check the path of where the request from the API need an X-Http-Method-Override header
+      if (Constants.APIS_WITH_EXTRA_HEADER.contains(path) && Objects.equals(verb, Constants.POST)) {
+        headers.put(Constants.X_HTTP_METHOD_OVERRIDE, Constants.GET);
+      }
+
     }
+
   }
 
   // Determines the User-Agent header, based on the client version, language version, and custom

--- a/src/main/java/com/amadeus/Request.java
+++ b/src/main/java/com/amadeus/Request.java
@@ -142,7 +142,7 @@ public class Request {
       headers.put(Constants.AUTHORIZATION, bearerToken);
       headers.put(Constants.CONTENT_TYPE, "application/vnd.amadeus+json");
 
-      // Check the path of where the request from the API need an X-Http-Method-Override header
+      // Checks if the request needs an X-Http-Method-Override header
       if (Constants.APIS_WITH_EXTRA_HEADER.contains(path) && Objects.equals(verb, Constants.POST)) {
         headers.put(Constants.X_HTTP_METHOD_OVERRIDE, Constants.GET);
       }

--- a/src/test/java/com/amadeus/RequestTest.java
+++ b/src/test/java/com/amadeus/RequestTest.java
@@ -110,7 +110,7 @@ public class RequestTest {
 
   @Test public void testRequestWithHttpOverrideHeader() {
     Amadeus amadeus = Amadeus.builder("123", "234").build();
-    for(String path : Constants.APIS_WITH_EXTRA_HEADER) {
+    for (String path : Constants.APIS_WITH_EXTRA_HEADER) {
       Request request = new Request("POST", path, null, null,"token", amadeus);
       assertEquals(request.getHeaders().get(Constants.X_HTTP_METHOD_OVERRIDE), "GET");
     }

--- a/src/test/java/com/amadeus/RequestTest.java
+++ b/src/test/java/com/amadeus/RequestTest.java
@@ -2,6 +2,7 @@ package com.amadeus;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -99,5 +100,19 @@ public class RequestTest {
     Request request = new Request("POST", "/v1/security/oauth2/token", null, null,null, amadeus);
     request.establishConnection();
     assertNotNull(request.getConnection());
+  }
+
+  @Test public void testRequestWithoutHttpOverrideHeader() {
+    Amadeus amadeus = Amadeus.builder("123", "234").build();
+    Request request = new Request("GET", "/foo/bar", null, null,"token", amadeus);
+    assertNull(request.getHeaders().get(Constants.X_HTTP_METHOD_OVERRIDE));
+  }
+
+  @Test public void testRequestWithHttpOverrideHeader() {
+    Amadeus amadeus = Amadeus.builder("123", "234").build();
+    for(String path : Constants.APIS_WITH_EXTRA_HEADER) {
+      Request request = new Request("POST", path, null, null,"token", amadeus);
+      assertEquals(request.getHeaders().get(Constants.X_HTTP_METHOD_OVERRIDE), "GET");
+    }
   }
 }


### PR DESCRIPTION
This PR is for adding support for the APIs (eg. Flight Availability) that need X-HTTP-Method-Override Header.
Idea overview:
Create a Constant ArrayList which adds all the paths of APIs that need this header.
And use an IF function to check if the path from Request is included in that ArrayList. 
