### PR TITLE
Make delays in DatedFlight.Timing accept an array

### DIFF
--- a/src/main/java/com/amadeus/resources/DatedFlight.java
+++ b/src/main/java/com/amadeus/resources/DatedFlight.java
@@ -66,7 +66,7 @@ public class DatedFlight extends Resource {
 
     private @Getter String qualifier;
     private @Getter String value;
-    private @Getter Delay delays;
+    private @Getter Delay[] delays;
   }
 
   @ToString


### PR DESCRIPTION
Delays is an array of Delay, not an object.

Fixes #178

## Changes for this pull request

## Checklist

Tests are all :heavy_check_mark: 

