### PR TITLE
build support for jdk 8 & 11

### DIFF
--- a/.github/workflows/build_gradle.yml
+++ b/.github/workflows/build_gradle.yml
@@ -13,12 +13,18 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+    env:
+      JDK_VERSION: ${{ matrix.java }}
+    name: Java ${{ matrix.java }} build
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v3
+    - name: Set up Java
+      uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: ${{ matrix.java }}
         distribution: 'adopt'
         cache: gradle
     - name: Grant execute permission for gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,11 @@ repositories {
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.9.0'
-    implementation "org.projectlombok:lombok:1.16.16"
-    testImplementation "org.mockito:mockito-core:2.12.0"
+    compileOnly "org.projectlombok:lombok:1.18.24"
+    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    testCompileOnly 'org.projectlombok:lombok:1.18.24'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
     testRuntimeOnly "org.slf4j:slf4j-api:1.7.10"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-    id 'io.franzbecker.gradle-lombok' version '4.0.0'
+    id 'io.franzbecker.gradle-lombok' version '5.0.0'
     id 'checkstyle'
     id 'com.vanniktech.maven.publish' version '0.18.0'
     id 'jacoco'
@@ -31,12 +31,10 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok:1.18.24'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
     testImplementation 'org.mockito:mockito-core:4.6.1'
-    testRuntimeOnly "org.slf4j:slf4j-api:1.7.10"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.github.tomakehurst:wiremock:2.27.2'
-    testImplementation 'io.rest-assured:rest-assured:5.0.0'
     testImplementation 'org.slf4j:slf4j-api:1.7.36'
     testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 }

--- a/src/main/java/com/amadeus/Request.java
+++ b/src/main/java/com/amadeus/Request.java
@@ -1,8 +1,5 @@
 package com.amadeus;
 
-import com.amadeus.Constants;
-
-import com.google.gson.JsonElement;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;


### PR DESCRIPTION
updated dependencies (lombok, mockito) in build.gradle to support up to and including JDK 15
changed build_gradle.yml to support both JDK 8 & 11
remove redundant imports from Request.java

Fixes #

## Changes for this pull request
please refer to the conversation here [https://github.com/amadeus4dev/amadeus-java/issues/184](url)

## Checklist

