### PR TITLE
release 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+
+6.3.0 - 2022-08-23
+--------------------
+Add support for the [Travel Restrictions v2](https://developers.amadeus.com/self-service/category/covid-19-and-travel-safety/api-doc/travel-restrictions/api-reference)
+
+Add support for JDK 8 and 11, Big thanks to [Steve Donovan](https://github.com/steve-donovan) for his contribution! :clap:
+
+Update Traveler resource model, Big thanks to [Steve Donovan](https://github.com/steve-donovan) for his contribution! :clap:
+
+Add [SonarCloud](https://sonarcloud.io/summary/overall?id=amadeus4dev_amadeus-java) in GitHub Action
+
 6.2.1 - 2022-07-22
 --------------------
 Removed unnecessary toString() on a String. Big thanks to [Steve Donovan](https://github.com/steve-donovan) for his contribution! :clap:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This library requires Java 1.7+ and the [Gson library](https://github.com/google
 <dependency>
   <groupId>com.amadeus</groupId>
   <artifactId>amadeus-java</artifactId>
-  <version>6.2.1</version>
+  <version>6.3.0</version>
 </dependency>
 ```
 #### Gradle
 ```js
-compile "com.amadeus:amadeus-java:6.2.1"
+compile "com.amadeus:amadeus-java:6.3.0"
 ```
 
 ## Getting Started

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.amadeus
-VERSION_NAME=6.2.1
+VERSION_NAME=6.3.0
 
 POM_URL=https://github.com/amadeus4dev/amadeus-java
 POM_SCM_URL=git@github.com:amadeus4dev/amadeus-java.git

--- a/src/main/java/com/amadeus/Amadeus.java
+++ b/src/main/java/com/amadeus/Amadeus.java
@@ -25,7 +25,7 @@ public class Amadeus extends HTTPClient {
   /**
    * The API version.
    */
-  public static final String VERSION = "6.2.1";
+  public static final String VERSION = "6.3.0";
 
   /**
    * <p>

--- a/src/test/java/com/amadeus/AmadeusTest.java
+++ b/src/test/java/com/amadeus/AmadeusTest.java
@@ -61,7 +61,7 @@ public class AmadeusTest {
   }
 
   @Test public void testVersion() {
-    assertEquals(Amadeus.VERSION, "6.2.1", "should have a version number");
+    assertEquals(Amadeus.VERSION, "6.3.0", "should have a version number");
   }
 
 }


### PR DESCRIPTION
@jabrena, can you please review this PR and merge it?  I will release the new version according to the guideline once you confirm.

6.3.0 - 2022-08-23
--------------------
Add support for the [Travel Restrictions v2](https://developers.amadeus.com/self-service/category/covid-19-and-travel-safety/api-doc/travel-restrictions/api-reference)

Add support for JDK 8 and 11, Big thanks to [Steve Donovan](https://github.com/steve-donovan) for his contribution! :clap:

Update Traveler resource model, Big thanks to [Steve Donovan](https://github.com/steve-donovan) for his contribution! :clap:

Add [SonarCloud](https://sonarcloud.io/summary/overall?id=amadeus4dev_amadeus-java) in GitHub Action