### PR TITLE
Add middle name in Traveler model

### DIFF
--- a/src/main/java/com/amadeus/resources/FlightOrder.java
+++ b/src/main/java/com/amadeus/resources/FlightOrder.java
@@ -54,6 +54,12 @@ public class FlightOrder extends Resource {
     private @Getter @Setter String firstName;
     private @Getter @Setter String lastName;
     private @Getter @Setter String middleName;
+
+    // Constructor with firstName and lastName only
+    public Name(String firstName, String lastName) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+    }
   }
 
   @AllArgsConstructor

--- a/src/main/java/com/amadeus/resources/FlightOrder.java
+++ b/src/main/java/com/amadeus/resources/FlightOrder.java
@@ -53,6 +53,7 @@ public class FlightOrder extends Resource {
 
     private @Getter @Setter String firstName;
     private @Getter @Setter String lastName;
+    private @Getter @Setter String middleName;
   }
 
   @AllArgsConstructor


### PR DESCRIPTION
Fixes #262 

The `Name` class updated to allow developers pass the traveler `middleName`. An extra constructor added in order to ensure that the new field is optional.
