### PR TITLE
Add brandedFareLabel to FareDetailsBySegment

### DIFF
--- a/src/main/java/com/amadeus/resources/FlightOfferSearch.java
+++ b/src/main/java/com/amadeus/resources/FlightOfferSearch.java
@@ -167,6 +167,7 @@ public class FlightOfferSearch extends Resource {
     private @Getter String cabin;
     private @Getter String fareBasis;
     private @Getter String brandedFare;
+    private @Getter String brandedFareLabel;
     @SerializedName("class")
     private @Getter String segmentClass;
     private @Getter boolean isAllotment;


### PR DESCRIPTION
Fixes #270 

## Changes for this pull request

Add missing field `brandedFareLabel` to the `FareDetailsBySegment` class.
